### PR TITLE
Add hfa and pv parameter to request payload

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -4,6 +4,7 @@ import * as utils from '../src/utils';
 
 const BIDDER_CODE = 'sonobi';
 const STR_ENDPOINT = 'https://apex.go.sonobi.com/trinity.json';
+const PAGEVIEW_ID = utils.generateUUID();
 
 export const spec = {
   code: BIDDER_CODE,
@@ -43,7 +44,12 @@ export const spec = {
       'key_maker': JSON.stringify(Object.assign({}, ...bids)),
       'ref': getTopWindowLocation().host,
       's': utils.generateUUID(),
+      'pv': PAGEVIEW_ID,
     };
+
+    if (validBidRequests[0].params.hfa) {
+      payload.hfa = validBidRequests[0].params.hfa;
+    }
 
     return {
       method: 'GET',

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -130,11 +130,25 @@ describe('SonobiBidAdapter', () => {
 
     it('should return a properly formatted request', () => {
       const bidRequests = spec.buildRequests(bidRequest)
+      const bidRequestsPageViewID = spec.buildRequests(bidRequest)
       expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json')
       expect(bidRequests.method).to.equal('GET')
       expect(bidRequests.data.key_maker).to.deep.equal(JSON.stringify(keyMakerData))
       expect(bidRequests.data.ref).not.to.be.empty
       expect(bidRequests.data.s).not.to.be.empty
+      expect(bidRequests.data.pv).to.equal(bidRequestsPageViewID.data.pv)
+      expect(bidRequests.data.hfa).to.not.exist
+    })
+
+    it('should return a properly formatted request with hfa', () => {
+      bidRequest[0].params.hfa = 'hfakey'
+      bidRequest[1].params.hfa = 'hfakey'
+      const bidRequests = spec.buildRequests(bidRequest)
+      expect(bidRequests.url).to.equal('https://apex.go.sonobi.com/trinity.json')
+      expect(bidRequests.method).to.equal('GET')
+      expect(bidRequests.data.ref).not.to.be.empty
+      expect(bidRequests.data.s).not.to.be.empty
+      expect(bidRequests.data.hfa).to.equal('hfakey')
     })
   })
 


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add hfa and pv parameter to request payload. hfa parameter is optional and can be set by the end user.

- apex.prebid@sonobi.com
- [x] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
